### PR TITLE
Updating construct to 2.8 and making file search case insensitive

### DIFF
--- a/fxp2aupreset.py
+++ b/fxp2aupreset.py
@@ -15,15 +15,6 @@ from xml.dom import minidom
 from base64 import b64encode
 from vst2preset import vst2preset
 
-
-def findfiles(which, where='.'):
-    '''Returns list of filenames from `where` path matched by 'which'
-       shell pattern. Matching is case-insensitive.'''
-    
-    # TODO: recursive param with walk() filtering
-    rule = re.compile(fnmatch.translate(which), re.IGNORECASE)
-    return [name for name in listdir(where) if rule.match(name)]
-
 # converts a four character identifier to an integer
 def id_to_integer(id):
     if (len(id) != 4):
@@ -184,7 +175,7 @@ def main():
     # enumerate all the .fxp files in the current directory
     chdir(args.path)
 
-    fxpFileList = findfiles('*.fxp',args.path)
+    fxpFileList = fnmatch.filter(listdir(args.path), '*.[Ff][Xx][BbPp]')
 
     if (len(fxpFileList) == 0):
         print "No .fxp or .fxb files found in '%s'" % (getcwd())

--- a/fxp2aupreset.py
+++ b/fxp2aupreset.py
@@ -7,13 +7,22 @@
 # http://www.rawmaterialsoftware.com/viewtopic.php?f=8&t=8337
 
 import argparse
-import os
+import re
 from os import path, listdir, getcwd, chdir
 import sys
+import fnmatch
 from xml.dom import minidom
-from glob import glob
 from base64 import b64encode
 from vst2preset import vst2preset
+
+
+def findfiles(which, where='.'):
+    '''Returns list of filenames from `where` path matched by 'which'
+       shell pattern. Matching is case-insensitive.'''
+    
+    # TODO: recursive param with walk() filtering
+    rule = re.compile(fnmatch.translate(which), re.IGNORECASE)
+    return [name for name in listdir(where) if rule.match(name)]
 
 # converts a four character identifier to an integer
 def id_to_integer(id):
@@ -173,12 +182,12 @@ def main():
     args = get_arguments(parser)
 
     # enumerate all the .fxp files in the current directory
-    os.chdir(args.path)
+    chdir(args.path)
 
-    fxpFileList = glob("*.fxp")
+    fxpFileList = findfiles('*.fxp',args.path)
 
     if (len(fxpFileList) == 0):
-        print "No .fxp files found in '%s'" % (os.getcwd())
+        print "No .fxp or .fxb files found in '%s'" % (getcwd())
 
     for fname in fxpFileList:
         convert(fname, args.manufacturer, args.subtype, args.type,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-construct==2.5.2
+construct==2.8.11

--- a/vst2preset.py
+++ b/vst2preset.py
@@ -3,40 +3,40 @@
 # based on VST SDK's vst2.x/vstfxstore.h
 # names as in the source
 
-from construct import Array, BFloat32, Bytes, Const, Container, Enum, \
-    LazyBound, String, Struct, Switch, UBInt32, ULInt32
+from construct import Array, Float32b, Bytes, Const, Container, Enum, \
+    LazyBound, String, Struct, Switch, Int32ub, Int32ul
 
-vst2preset = Struct('vst2preset',
-    Const(Bytes('chunkMagic', 4), 'CcnK'),
-    UBInt32('byteSize'),
-    Enum(Bytes('fxMagic', 4),
-        FXP_PARAMS = 'FxCk', FXP_OPAQUE_CHUNK = 'FPCh',
-        FXB_REGULAR = 'FxBk', FXB_OPAQUE_CHUNK = 'FBCh',
-        ),
-    UBInt32('version'),
-    UBInt32('fxID'),
-    UBInt32('fxVersion'),
-    UBInt32('count'),
-    Switch('data', lambda ctx: ctx['fxMagic'], {
-        'FXP_PARAMS': Struct('data',
-            String('prgName', 28, padchar = '\0'),
-            Array(lambda ctx: ctx['_']['count'], BFloat32('params')),
-            ),
-        'FXP_OPAQUE_CHUNK': Struct('data',
-            String('prgName', 28, padchar = '\0'),
-            UBInt32('size'),
-            Bytes('chunk', lambda ctx: ctx['size']),
-            ),
-        'FXB_REGULAR': Struct('data',
-            Bytes('future', 128), # zeros
-            # Array of FXP_PARAMS vst2preset
-            Array(lambda ctx: ctx['_']['count'], LazyBound('presets', lambda: vst2preset)),
-            ),
-        'FXB_OPAQUE_CHUNK': Struct('data',
-            Bytes('future', 128), # zeros
-            UBInt32('size'),
-            # Unknown format of internal chunk
-            Bytes('chunk', lambda ctx: ctx['size']),
-            ),
-        }),
+vst2preset = Struct(
+    'chunkMagic' / Const(b"CcnK"),
+    "byteSize" / Int32ub,
+    "fxMagic" / Enum(Bytes(4),
+       FXP_PARAMS = b'FxCk', FXP_OPAQUE_CHUNK = b'FPCh',
+       FXB_REGULAR = b'FxBk', FXB_OPAQUE_CHUNK = b'FBCh',
+    ),
+    "version" / Int32ub,
+    "fxID" / Int32ub,
+    "fxVersion" / Int32ub,
+    "count" / Int32ub,
+    # Switch('data', lambda ctx: ctx['fxMagic'], {
+    #     'FXP_PARAMS': Struct('data',
+    #         String('prgName', 28, padchar = '\0'),
+    #         Array(lambda ctx: ctx['_']['count'], Float32b('params')),
+    #         ),
+    #     'FXP_OPAQUE_CHUNK': Struct('data',
+    #         String('prgName', 28, padchar = '\0'),
+    #         Int32ub('size'),
+    #         Bytes('chunk', lambda ctx: ctx['size']),
+    #         ),
+    #     'FXB_REGULAR': Struct('data',
+    #         Bytes('future', 128), # zeros
+    #         # Array of FXP_PARAMS vst2preset
+    #         Array(lambda ctx: ctx['_']['count'], LazyBound('presets', lambda: vst2preset)),
+    #         ),
+    #     'FXB_OPAQUE_CHUNK': Struct('data',
+    #         Bytes('future', 128), # zeros
+    #         Int32ub('size'),
+    #         # Unknown format of internal chunk
+    #         Bytes('chunk', lambda ctx: ctx['size']),
+    #         ),
+    #     }),
     )

--- a/vst2preset.py
+++ b/vst2preset.py
@@ -7,7 +7,7 @@ from construct import Array, Float32b, Bytes, Const, Container, Enum, \
     LazyBound, String, Struct, Switch, Int32ub, Int32ul
 
 vst2preset = Struct(
-    'chunkMagic' / Const(b"CcnK"),
+    "chunkMagic" / Const(b"CcnK"),
     "byteSize" / Int32ub,
     "fxMagic" / Enum(Bytes(4),
        FXP_PARAMS = b'FxCk', FXP_OPAQUE_CHUNK = b'FPCh',
@@ -17,26 +17,26 @@ vst2preset = Struct(
     "fxID" / Int32ub,
     "fxVersion" / Int32ub,
     "count" / Int32ub,
-    # Switch('data', lambda ctx: ctx['fxMagic'], {
-    #     'FXP_PARAMS': Struct('data',
-    #         String('prgName', 28, padchar = '\0'),
-    #         Array(lambda ctx: ctx['_']['count'], Float32b('params')),
-    #         ),
-    #     'FXP_OPAQUE_CHUNK': Struct('data',
-    #         String('prgName', 28, padchar = '\0'),
-    #         Int32ub('size'),
-    #         Bytes('chunk', lambda ctx: ctx['size']),
-    #         ),
-    #     'FXB_REGULAR': Struct('data',
-    #         Bytes('future', 128), # zeros
-    #         # Array of FXP_PARAMS vst2preset
-    #         Array(lambda ctx: ctx['_']['count'], LazyBound('presets', lambda: vst2preset)),
-    #         ),
-    #     'FXB_OPAQUE_CHUNK': Struct('data',
-    #         Bytes('future', 128), # zeros
-    #         Int32ub('size'),
-    #         # Unknown format of internal chunk
-    #         Bytes('chunk', lambda ctx: ctx['size']),
-    #         ),
-    #     }),
+    "data" / Switch(lambda ctx: ctx.fxMagic, {
+        'FXP_PARAMS': "data" / Struct(
+            "prgName" / String(28, padchar='\0'),
+            Array(lambda ctx: ctx['_']['count'], "params" / Float32b),
+            ),
+        'FXP_OPAQUE_CHUNK': "data" / Struct(
+            "prgName" / String(28, padchar='\0'),
+            "size" / Int32ub,
+            "chunk" / Bytes(lambda ctx: ctx['size']),
+            ),
+        'FXB_REGULAR': "data" / Struct(
+            "future" / Bytes(128), # zeros
+            # Array of FXP_PARAMS vst2preset
+            Array(lambda ctx: ctx['_']['count'], "presets" / LazyBound(lambda: vst2preset)),
+            ),
+        'FXB_OPAQUE_CHUNK': "data" / Struct(
+            "future" / Bytes(128), # zeros
+            "size" / Int32ub,
+            # Unknown format of internal chunk
+            "chunk" / Bytes(lambda ctx: ctx['size']),
+            ),
+    }),
     )


### PR DESCRIPTION
Hi. Construct 2.5 is not maintained anymore. I updated the code to construct 2.8 and make file search of fxp files case insensitive too (Mac OS file system is strangely case-insensitive by default, if I rename FILE.FXP to file.fxp I got an error, but if I search for a fxp file, the command is case sensitive).